### PR TITLE
Fix #6 and use const char where possible.

### DIFF
--- a/src/seatest.h
+++ b/src/seatest.h
@@ -6,7 +6,7 @@
 Defines
 */
 
-#define SEATEST_VERSION "1.1.0"
+#define SEATEST_VERSION "2.0.0-alpha1"
 #define SEATEST_PROJECT_HOME "https://github.com/mcci-usb/seatest/"
 #define SEATEST_PRINT_BUFFER_SIZE 100000
 

--- a/src/seatest.h
+++ b/src/seatest.h
@@ -19,17 +19,20 @@ int skip_failed_test;
 /*
 Typedefs
 */
+typedef void seatest_void_void_fn_t(void);
+typedef seatest_void_void_fn_t *seatest_void_void;
 
-typedef void (*seatest_void_void)(void);
-typedef void (*seatest_void_string)(char*);
+typedef void (*seatest_void_string)(const char*);
+typedef void (seatest_simple_test_result_fn_t)(int passed, const char* reason, const char* function, unsigned int line);
+
 
 /*
 Declarations
 */
-void (*seatest_simple_test_result)(int passed, char* reason, const char* function, unsigned int line);
-void seatest_test_fixture_start(char* filepath);
+seatest_simple_test_result_fn_t *seatest_simple_test_result;
+void seatest_test_fixture_start(const char* filepath);
 void seatest_test_fixture_end( void );
-void seatest_simple_test_result_log(int passed, char* reason, const char* function, unsigned int line);
+seatest_simple_test_result_fn_t seatest_simple_test_result_log;
 void seatest_assert_true(int test, const char* function, unsigned int line);
 void seatest_assert_false(int test, const char* function, unsigned int line);
 void seatest_assert_int_equal(int expected, int actual, const char* function, unsigned int line);
@@ -37,19 +40,19 @@ void seatest_assert_ulong_equal(unsigned long expected, unsigned long actual, co
 void seatest_assert_size_t_equal(size_t expected, size_t actual, const char* function, unsigned int line);
 void seatest_assert_float_equal(float expected, float actual, float delta, const char* function, unsigned int line);
 void seatest_assert_double_equal(double expected, double actual, double delta, const char* function, unsigned int line);
-void seatest_assert_string_equal(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_ends_with(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_starts_with(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_contains(char* expected, char* actual, const char* function, unsigned int line);
-void seatest_assert_string_doesnt_contain(char* expected, char* actual, const char* function, unsigned int line);
-int  seatest_should_run( char* fixture, char* test);
-void seatest_before_run( char* fixture, char* test);
-void seatest_run_test(char* fixture, char* test);
+void seatest_assert_string_equal(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_ends_with(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_starts_with(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_contains(const char* expected, const char* actual, const char* function, unsigned int line);
+void seatest_assert_string_doesnt_contain(const char* expected, const char* actual, const char* function, unsigned int line);
+int  seatest_should_run( const char* fixture, const char* test);
+void seatest_before_run( const char* fixture, const char* test);
+void seatest_run_test(const char* fixture, const char* test);
 void seatest_setup( void );
 void seatest_teardown( void );
 void seatest_suite_teardown( void );
 void seatest_suite_setup( void );
-void seatest_test(char* fixture, char* test, void(*test_function)(void));
+void seatest_test(const char* fixture, const char* test, void(*test_function)(void));
 /*
 Assert Macros
 */
@@ -77,12 +80,12 @@ Fixture / Test Management
 
 void fixture_setup(void (*setup)( void ));
 void fixture_teardown(void (*teardown)( void ));
-//#define run_test(test) do { if(seatest_should_run(__FILE__, #test)) {seatest_suite_setup(); seatest_setup(); test(); seatest_teardown(); seatest_suite_teardown(); seatest_run_test(__FILE__, #test);  }} while (0)
+/* #define run_test(test) do { if(seatest_should_run(__FILE__, #test)) {seatest_suite_setup(); seatest_setup(); test(); seatest_teardown(); seatest_suite_teardown(); seatest_run_test(__FILE__, #test);  }} while (0) */
 #define run_test(test) do { seatest_test(__FILE__, #test, test);} while (0)
 #define test_fixture_start() do { seatest_test_fixture_start(__FILE__); } while (0)
 #define test_fixture_end() do { seatest_test_fixture_end();} while (0)
-void fixture_filter(char* filter);
-void test_filter(char* filter);
+void fixture_filter(const char* filter);
+void test_filter(const char* filter);
 void suite_teardown(seatest_void_void teardown);
 void suite_setup(seatest_void_void setup);
 int run_tests(seatest_void_void tests);
@@ -90,7 +93,7 @@ int seatest_testrunner(int argc, char** argv, seatest_void_void tests, seatest_v
 #endif
 
 #ifdef SEATEST_INTERNAL_TESTS
-void seatest_simple_test_result_nolog(int passed, char* reason, const char* function, unsigned int line);
+seatest_simple_test_result_fn_t seatest_simple_test_result_nolog;
 void seatest_assert_last_passed();
 void seatest_assert_last_failed();
 void seatest_enable_logging();


### PR DESCRIPTION
The library used `char *` rather than `const char *` for paramters passed from the user's test, precluding use of `const char *` tables. This change fixes that. As usual, things ripple through, and I decided it was better to change all the types at once (not just on the asserts).

This change is a breaking change; therefore the version is updated to V2.0.0-alpha1. I may batch further breaking changes prior to the official v2.0.0 tag.